### PR TITLE
Add annotation to avoid Swift compilation errors in Xcode 10 beta 3

### DIFF
--- a/CwlDemangle.swift
+++ b/CwlDemangle.swift
@@ -4265,7 +4265,7 @@ fileprivate struct ScalarScanner<C: Collection> where C.Iterator.Element == Unic
     }
     
     /// Throw if the scalars at the current `index` don't match the scalars in `value`. Advance the `index` to the end of the match.
-    mutating func match(where test: (UnicodeScalar) -> Bool) throws {
+    mutating func match(where test: @escaping (UnicodeScalar) -> Bool) throws {
         if index == scalars.endIndex || !test(scalars[index]) {
             throw SwiftSymbolParseError.matchFailed(wanted: String(describing: test), at: consumed)
         }
@@ -4274,7 +4274,7 @@ fileprivate struct ScalarScanner<C: Collection> where C.Iterator.Element == Unic
     }
     
     /// Throw if the scalars at the current `index` don't match the scalars in `value`. Advance the `index` to the end of the match.
-    mutating func read(where test: (UnicodeScalar) -> Bool) throws -> UnicodeScalar {
+    mutating func read(where test: @escaping (UnicodeScalar) -> Bool) throws -> UnicodeScalar {
         if index == scalars.endIndex || !test(scalars[index]) {
             throw SwiftSymbolParseError.matchFailed(wanted: String(describing: test), at: consumed)
         }


### PR DESCRIPTION
See: https://github.com/apple/swift-evolution/blob/master/proposals/0103-make-noescape-default.md

<img width="823" alt="screen shot 2018-07-06 at 9 15 32 am" src="https://user-images.githubusercontent.com/9206755/42389600-13d9ddd0-80fe-11e8-9808-045bd96c9c17.png">
